### PR TITLE
fix compilation error against llvm/clang trunk

### DIFF
--- a/lib/CrispLLVMPass/CrispModulePass.cpp
+++ b/lib/CrispLLVMPass/CrispModulePass.cpp
@@ -31,7 +31,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Target/TargetData.h"
+#include "llvm/DataLayout.h"
 
 #include "crisp/RunPrologEngine.h"
 #include "LLVMCompilationInfo.h"
@@ -148,7 +148,7 @@ namespace crisp {
   void CrispModulePass::getAnalysisUsage(AnalysisUsage& AU) const {
     AU.setPreservesAll();
     AU.addRequired<AliasAnalysis>();
-    AU.addRequired<TargetData>(); // Necessary to get location sizes
+    AU.addRequired<DataLayout>(); // Necessary to get location sizes
   }
 
   void CrispModulePass::releaseMemory() {

--- a/lib/CrispLLVMPass/LLVMDeclarations.cpp
+++ b/lib/CrispLLVMPass/LLVMDeclarations.cpp
@@ -24,7 +24,7 @@
 #include "llvm/Module.h"
 #include "llvm/Support/InstIterator.h"
 #include "llvm/Use.h"
-#include "llvm/Target/TargetData.h"
+#include "llvm/DataLayout.h"
 #include "llvm/Type.h"
 
 int main() {

--- a/lib/CrispLLVMPass/LLVMPrologPredicates.cpp
+++ b/lib/CrispLLVMPass/LLVMPrologPredicates.cpp
@@ -28,7 +28,7 @@
 #include "llvm/Support/InstIterator.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Use.h"
-#include "llvm/Target/TargetData.h"
+#include "llvm/DataLayout.h"
 #include "llvm/Type.h"
 
 #include "crisp/PrologPredBaseTemplates.h"
@@ -179,8 +179,8 @@ namespace crisp {
       const Pass &P = getLLVMCompilationInfo()->getPass();
       Location L;
       if (ElementTypeOfV->isSized()) {
-        TargetData& TD = P.getAnalysis<TargetData>();
-        uint64_t Size = TD.getTypeAllocSize(ElementTypeOfV);
+        DataLayout const & DL = P.getAnalysis<DataLayout>();
+        uint64_t const Size = DL.getTypeAllocSize(ElementTypeOfV);
         L = Location(V, Size);
       } else {
         L = Location(V);


### PR DESCRIPTION
tried to compile Crisp against the latest llvm/clang trunk, but found compilation errors.

it started with this compiler error:

> 'llvm/Target/TargetData.h' file not found

and concluded, that the whole type was reworked. the relevant commits are these:

> ---
> 
> r165404 | mvillmow | 2012-10-08 18:40:38 +0200 (Mon, 08 Oct 2012) | 1 line
> ## Move TargetData to DataLayout.
> 
> r165403 | mvillmow | 2012-10-08 18:39:34 +0200 (Mon, 08 Oct 2012) | 1 line
> ## Move TargetData to DataLayout.
> 
> r165402 | mvillmow | 2012-10-08 18:38:25 +0200 (Mon, 08 Oct 2012) | 1 line
> ## Move TargetData to DataLayout.
> 
> r165401 | mvillmow | 2012-10-08 18:37:04 +0200 (Mon, 08 Oct 2012) | 1 line
> 
> Move TargetData to DataLayout.
